### PR TITLE
Enforce solution-wide tabbing standard, pull back icon null check

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+# top-most EditorConfig file
+root = true
+
+# All code files
+[*.{cs,xaml}]
+indent_style = space
+indent_size = 4

--- a/Common/Helpers/IconHelper.cs
+++ b/Common/Helpers/IconHelper.cs
@@ -20,18 +20,10 @@ namespace Wokhan.WindowsFirewallNotifier.Common.Helpers
         private static BitmapSource GetIconFromPath(string path, bool defaultIfNotFound = false)
         {
             Icon ic = null;
-            if (String.IsNullOrEmpty(path))
-            {
-                path = "?error";
-            }
             switch (path)
             {
                 case "System":
                     ic = SystemIcons.WinLogo;
-                    break;
-
-                case "?error": //FIXME: Use something else?
-                    ic = SystemIcons.Error;
                     break;
 
                 default:
@@ -78,6 +70,11 @@ namespace Wokhan.WindowsFirewallNotifier.Common.Helpers
         /// <returns></returns>
         public static BitmapSource GetIcon(string path, bool defaultIfNotFound = false)
         {
+            if (String.IsNullOrEmpty(path))
+            {
+                path = String.Empty;
+            }
+
             BitmapSource icon;
             if (!procIconLst.ContainsKey(path))
             {

--- a/WindowsFirewallNotifier.sln
+++ b/WindowsFirewallNotifier.sln
@@ -11,6 +11,11 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Console", "Console\Console.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Common", "Common\Common.csproj", "{94028C5E-9B0E-4D15-966A-9FA766A20821}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8868B2A5-29B2-4774-B32D-913A242232BC}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU


### PR DESCRIPTION
Sorry I created all of that extra work for you with my fix! For the first half of this PR, I added a solution-wide editorconfig that enforces the preference of four spaces per tab. That way I or anyone else who contribute won't stomp on your preference of tab style. :) By the way, coding style standards can also be enforced (I see a FIXME somewhere about a redundant "this" which would normally be removed).

For the second half of this PR: I'm trying to understand [this change](https://github.com/wokhansoft/WFN/commit/3ef1aa7ef23a2cb777575660962588debadac36d), because it reintroduces a bug I was previously experiencing (and thought was at least [temporarily fixed)](https://github.com/wokhansoft/WFN/commit/16f147e9a896066d1424a4a4b0857c98e04f4e4a).

When the ListView tries to draw a `Rule` with a null `ApplicationName`, the application will crash with an unhandled `System.ArgumentNullException` in IconHelper.cs:82. This happens because IconHelper.GetIcon() is called with a null value, and it therefor tries to call ContainsKey() with that null value which doesn't work (keys cannot be null). The program is unable to reach the point in `GetIconFromPath()` where the fix was moved to. My fix in `FirewallHelper.cs` originally intended to work around these special Rules by replacing the absence of any value with an empty string, at least providing something for the program to work with.

As far as fixing this goes, perhaps we can compromise at putting the check in `GetIcon()`, and then using the `WarningIcon` as the default case dictates?