### PR TITLE
Enable console width/height in options and some layout improvements

### DIFF
--- a/Common/Settings.Designer.cs
+++ b/Common/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace Wokhan.WindowsFirewallNotifier.Common {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "14.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.2.0.0")]
     public sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -34,7 +34,7 @@ namespace Wokhan.WindowsFirewallNotifier.Common {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("500")]
+        [global::System.Configuration.DefaultSettingValueAttribute("600")]
         public int ConsoleSizeHeight {
             get {
                 return ((int)(this["ConsoleSizeHeight"]));
@@ -144,7 +144,7 @@ namespace Wokhan.WindowsFirewallNotifier.Common {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("850")]
+        [global::System.Configuration.DefaultSettingValueAttribute("900")]
         public int ConsoleSizeWidth {
             get {
                 return ((int)(this["ConsoleSizeWidth"]));

--- a/Common/Settings.settings
+++ b/Common/Settings.settings
@@ -6,7 +6,7 @@
       <Value Profile="(Default)">True</Value>
     </Setting>
     <Setting Name="ConsoleSizeHeight" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">500</Value>
+      <Value Profile="(Default)">600</Value>
     </Setting>
     <Setting Name="ConsoleState" Type="System.Windows.WindowState" Scope="User">
       <Value Profile="(Default)">Normal</Value>
@@ -33,7 +33,7 @@
       <Value Profile="(Default)">True</Value>
     </Setting>
     <Setting Name="ConsoleSizeWidth" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">850</Value>
+      <Value Profile="(Default)">900</Value>
     </Setting>
     <Setting Name="AccentColor" Roaming="true" Type="System.Windows.Media.SolidColorBrush" Scope="User">
       <Value Profile="(Default)">#FFFF7F50</Value>

--- a/Console/App.xaml.cs
+++ b/Console/App.xaml.cs
@@ -48,6 +48,23 @@ namespace Wokhan.WindowsFirewallNotifier.Console
             {
                 Resources["AccentColorBrush"] = Settings.Default.AccentColor;
             }
+
+            if (Settings.Default.ConsoleSizeWidth > 900)
+            {
+                Resources["ConsoleSizeWidth"] = Convert.ToDouble(Settings.Default.ConsoleSizeWidth);
+            }
+            else
+            {
+                Resources["ConsoleSizeWidth"] = 900d;
+            }
+            if (Settings.Default.ConsoleSizeHeight > 600)
+            {
+                Resources["ConsoleSizeHeight"] = Convert.ToDouble(Settings.Default.ConsoleSizeHeight);
+            }
+            else
+            {
+                Resources["ConsoleSizeHeight"] = 600d;
+            }
         }
 
         internal void RestartAsAdmin()

--- a/Console/UI/Pages/Options.xaml
+++ b/Console/UI/Pages/Options.xaml
@@ -96,22 +96,26 @@ Please note that you will be able to do it later through the Options panel." Tex
                         </StackPanel>
                     </GroupBox>
                 </StackPanel-->
-                <ToggleButton Style="{StaticResource ToggleSwitch}" Padding="5,0" Content="Use an animated notification" Margin="0,0,0,10" IsChecked="{Binding UseAnimation, Source={x:Static settings:Settings.Default}}" />
-                <Button Style="{StaticResource RoundedButton}" Background="LightBlue" Margin="0,0,0,10" Padding="4"  HorizontalAlignment="Center" Content="Click here to test" x:Name="btnTestNotif" Click="btnTestNotif_Click" />
-                <ToggleButton Style="{StaticResource ToggleSwitch}" Padding="5,0" Content="Create a blocking rule instead of using an exceptions list for the blocked outgoing connections*" Margin="0,0,0,5" IsChecked="{Binding UseBlockRules, Source={x:Static settings:Settings.Default}}" IsEnabled="{Binding IsElevated,Source={x:Static Application.Current}}" />
-                <TextBlock Margin="30,0,0,10" Text="This option allows the blocked applications to stay blocked even if you disable WFN notifications, by creating a blocking rule in the Windows embedded firewall." TextWrapping="Wrap" IsEnabled="{Binding IsElevated,Source={x:Static Application.Current}}" />
-                <ToggleButton Style="{StaticResource ToggleSwitch}" Padding="5,0" Content="Enable services detection*" IsChecked="{Binding EnableServiceDetection, Source={x:Static settings:Settings.Default}}" IsEnabled="{Binding IsElevated,Source={x:Static Application.Current}}" />                
+                <StackPanel Orientation = "Horizontal">
+                    <ToggleButton Style="{StaticResource ToggleSwitch}" Padding="5,0" Content="Use an animated notification" Margin="0,0,22,10.2" IsChecked="{Binding UseAnimation, Source={x:Static settings:Settings.Default}}" />
+                    <Button Style="{StaticResource RoundedButton}" Background="LightBlue" Margin="171,0,169,10.2" Padding="4"  HorizontalAlignment="Center" Content="Click here to test" x:Name="btnTestNotif" Click="btnTestNotif_Click" />
+                </StackPanel>
+                <StackPanel Orientation = "Vertical">
+                    <ToggleButton Style="{StaticResource ToggleSwitch}" Padding="5,0" Content="Create a blocking rule instead of using an exceptions list for the blocked outgoing connections*" ToolTip="Default: True" Margin="0,0,0,5" IsChecked="{Binding UseBlockRules, Source={x:Static settings:Settings.Default}}" IsEnabled="{Binding IsElevated,Source={x:Static Application.Current}}" />
+                    <TextBlock Margin="30,0,0,10" Text="This option allows the blocked applications to stay blocked even if you disable WFN notifications, by creating a blocking rule in the Windows embedded firewall." TextWrapping="Wrap" IsEnabled="{Binding IsElevated, Source={x:Static Application.Current}}" />
+                </StackPanel>
+                <ToggleButton Style="{StaticResource ToggleSwitch}" Padding="5,0" Content="Enable services detection*" ToolTip="Additionally tries to detect the service making a connection in the notifier." IsChecked="{Binding EnableServiceDetection, Source={x:Static settings:Settings.Default}}" IsEnabled="{Binding IsElevated,Source={x:Static Application.Current}}" />
             </StackPanel>
             <Label Content="Miscellaneous options" Background="{DynamicResource AccentColorBrush}" FontWeight="Bold" />
             <StackPanel Margin="10">
-                <ToggleButton Style="{StaticResource ToggleSwitch}" Margin="0,0,0,10"  Padding="5,0" Content="Minimize the console to the system tray instead of the taskbar." IsChecked="{Binding MinimizeToTray, Source={x:Static settings:Settings.Default}}" />
+                <!-- TODO: not working  <ToggleButton Style="{StaticResource ToggleSwitch}" Margin="0,0,0,10"  Padding="5,0" Content="Minimize the console to the system tray instead of the taskbar." IsChecked="{Binding MinimizeToTray, Source={x:Static settings:Settings.Default}}" /> -->
                 <ToggleButton Style="{StaticResource ToggleSwitch}" Margin="0,0,0,10" Padding="5,0" Content="Enable verbose logging (for debugging purpose only, may use a lot more disk space)" IsChecked="{Binding EnableVerboseLogging, Source={x:Static settings:Settings.Default}}" />
                 <TextBlock Margin="30,0,0,10" Text="Note: the log files can either be in the WFN installation directory or the current user's appdata folder." />
-                <TextBlock Margin="30,0,0,10" Text="{Binding Source={x:Static helpers:LogHelper.CurrentLogsPath},Mode=OneTime,StringFormat='Path for the current user: {0}'}" Tag="{Binding Source={x:Static helpers:LogHelper.CurrentLogsPath}, Mode=OneTime}" x:Name="txtCurrentLogPath" MouseDown="txtCurrentLogPath_MouseDown"/>
-                <ToggleButton Style="{StaticResource ToggleSwitch}" Margin="0,0,0,10" Padding="5,0" Content="Always run as admin*" IsChecked="{Binding AlwaysRunAs, Source={x:Static settings:Settings.Default}}" IsEnabled="{Binding IsElevated,Source={x:Static Application.Current}}" />
-                <WrapPanel>
+                <TextBlock Margin="30,0,0,10" TextWrapping="Wrap" Text="{Binding Mode=OneTime, Source={x:Static helpers:LogHelper.CurrentLogsPath}, StringFormat=Path for the current user: \{0\}}" Tag="{Binding Mode=OneTime, Source={x:Static helpers:LogHelper.CurrentLogsPath}}" x:Name="txtCurrentLogPath" MouseDown="txtCurrentLogPath_MouseDown" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Height="Auto" Width="Auto"/>
+                <ToggleButton Style="{StaticResource ToggleSwitch}" Margin="0,0,0,10" Padding="5,0" Content="Always run as admin*" ToolTip="Options marked with * need admin rights to change" IsChecked="{Binding AlwaysRunAs, Source={x:Static settings:Settings.Default}}" IsEnabled="{Binding IsElevated,Source={x:Static Application.Current}}" />
+                <StackPanel Orientation="Horizontal">
                     <Label Content="Accent color: " />
-                    <ComboBox IsEditable="False" MinWidth="100" ItemsSource="{Binding Colors}" SelectedValuePath="Value" SelectedValue="{Binding AccentColor}">
+                    <ComboBox IsEditable="False" MinWidth="100" ItemsSource="{Binding Colors}" SelectedValuePath="Value" SelectedValue="{Binding AccentColor}" Height="20">
                         <ComboBox.ItemTemplate>
                             <DataTemplate>
                                 <WrapPanel>
@@ -121,7 +125,11 @@ Please note that you will be able to do it later through the Options panel." Tex
                             </DataTemplate>
                         </ComboBox.ItemTemplate>
                     </ComboBox>
-                </WrapPanel>
+                    <Label Content="Console Width" Margin="20,0,0,0"/>
+                    <TextBox Text="{Binding ConsoleSizeWidth, Source={x:Static settings:Settings.Default}}"  ToolTip="Needs a restart to take effect." IsEnabled="{Binding IsElevated,Source={x:Static Application.Current}}" Background="{DynamicResource {x:Static SystemColors.ControlLightBrushKey}}" Width="50" Height="20" />
+                    <Label Content="Height"/>
+                    <TextBox Text="{Binding ConsoleSizeHeight, Source={x:Static settings:Settings.Default}}" ToolTip="Needs a restart to take effect." IsEnabled="{Binding IsElevated,Source={x:Static Application.Current}}" Width="50" Background="{DynamicResource {x:Static SystemColors.ControlLightBrushKey}}" Height="20" />
+                </StackPanel>
             </StackPanel>
         </StackPanel>
     </DockPanel>

--- a/Console/UI/Pages/Options.xaml.cs
+++ b/Console/UI/Pages/Options.xaml.cs
@@ -56,5 +56,6 @@ namespace Wokhan.WindowsFirewallNotifier.Console.UI.Pages
         {
             Process.Start("explorer.exe", LogHelper.CurrentLogsPath);
         }
+
     }
 }

--- a/Console/UI/Windows/MainWindow.xaml
+++ b/Console/UI/Windows/MainWindow.xaml
@@ -2,8 +2,8 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="WFN v2.0 BETA"
-        Height="600"
-        Width="900"
+        Height="{DynamicResource ConsoleSizeHeight}" 
+        Width="{DynamicResource ConsoleSizeWidth}"
         DataContext="{Binding RelativeSource={RelativeSource Self}}"
         Icon="/WFN;component/Resources/Images/WFN.ico" 
         ResizeMode="CanResizeWithGrip">


### PR DESCRIPTION
This includes:
MainWindow:
- MainWindow size can be changed in Options

Options:
- Tidy up the settings a bit
- Commented out "Minimize the console" because it's not working / used
