### PR TITLE
Fix settings access modifier which leads to compile error after update

### DIFF
--- a/Common/Common.csproj
+++ b/Common/Common.csproj
@@ -42,6 +42,19 @@
   <ItemGroup>
     <Resource Include="Resources\Shield.ico" />
   </ItemGroup>
+  <ItemGroup>
+    <Compile Update="Settings.Designer.cs">
+      <DesignTimeSharedInput>True</DesignTimeSharedInput>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Settings.settings</DependentUpon>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="Settings.settings">
+      <Generator>PublicSettingsSingleFileGenerator</Generator>
+      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
+    </None>
+  </ItemGroup>
 
   <!--<ItemGroup>
     <Resource Include="Resources\Shield.ico" />

--- a/Common/Settings.Designer.cs
+++ b/Common/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace Wokhan.WindowsFirewallNotifier.Common {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.3.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.4.0.0")]
     public sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));


### PR DESCRIPTION
Set access notifier for settings to public instead of internal